### PR TITLE
account for parentKey being null in nested arrays

### DIFF
--- a/lib/src/json_differ.dart
+++ b/lib/src/json_differ.dart
@@ -152,7 +152,7 @@ class JsonDiffer {
           // TODO: This notation is wrong for a case such as:
           //     [1,2,3,4,5,6] => [1,4,5,7]
           //     changed.first = [[5, 6], [3,7]
-          if (atomics.contains(parentKey+"[]") && left[leftFoot].toString() != right[rightFoot].toString()) {
+          if (parentKey != null && atomics.contains(parentKey+"[]") && left[leftFoot].toString() != right[rightFoot].toString()) {
             // Treat leftValue and rightValue as atomic objects, even if they are
             // deep maps or some such thing.
             node.changed[leftFoot.toString()] = [left[leftFoot], right[rightFoot]];


### PR DESCRIPTION
parentKey can be null in situations like this:

```
JsonDiffer differ = new JsonDiffer(
    '{"something": [[1]]}',
    '{"something": [[2]]}'
  );
DiffNode diff = differ.diff();
```

This currently causes the following:

```
Exception: Unhandled exception:
The null object does not have a method '+'.

NoSuchMethodError: method not found: '+'
Receiver: null
Arguments: ["[]"]
```

The submitted change fixes this and the correct output DiffNode is returned.
