### PR TITLE
Adds new feature: moved elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ object, and a deeply changed object:
 ```dart
 import 'package:json_diff/json_diff.dart';
 
-Map<String,Object> left = '{"a": 2, "b": 3, "c": 5, "d": {"x": 4, "y": 8}}';
-Map<String,Object> right = '{"b": 7, "c": 5, "d": {"x": 4, "z": 16}, "e": 11}';
-differ = new JsonDiffer(left, right);
+final left = {"a": 2, "b": 3, "c": 5, "d": {"x": 4, "y": 8}};
+final right = {"b": 7, "c": 5, "d": {"x": 4, "z": 16}, "e": 11};
+final differ = JsonDiffer.fromJson(left, right);
 DiffNode diff = differ.diff();
-diff.added              // => {"e": 11}
-diff.removed            // => {"a": 2}
-diff.changed            // => {"b": [3, 7]}
-diff.node               // => a Map<String,DiffNode>
-diff.node['d']          // => a DiffNode
-diff.node['d'].added    // => {"z": 16}
-diff.node['d'].removed  // => {"y": 8}
+print(diff.added);              // => {"e": 11}
+print(diff.removed);            // => {"a": 2}
+print(diff.changed);            // => {"b": [3, 7]}
+print(diff.node);               // => a Map<String,DiffNode>
+print(diff.node['d']);          // => a DiffNode
+print(diff.node['d'].added);    // => {"z": 16}
+print(diff.node['d'].removed);  // => {"y": 8}
 ```
 
 So that's pretty fun. So when you diff two JSON strings, you get back a
@@ -38,8 +38,12 @@ got back has
   different in `left` and in `right`. The values in this Map are two-element
   Arrays. The 0th element is the old value (from `left`), and the 1st element
   is the new value (from `right`).
+* a `moved` property, which is a Map of indexes, where key is the original index 
+  of an element, and value is index in the changed list.
 * a `node` property, a Map of the properties found in both `left` and `right`
   that have deep differences. The values of this Map are more DiffNodes.
+* a `path` property, which is a List of indexes, describing the path from the root
+  where this DiffNode is operating.
 
 Contributing
 ------------

--- a/lib/src/json_differ.dart
+++ b/lib/src/json_differ.dart
@@ -81,7 +81,7 @@ class JsonDiffer {
 
   DiffNode _diffObjects(
       Map<String, Object> left, Map<String, Object> right, List<Object> path) {
-    final node = DiffNode(List.from(path));
+    final node = DiffNode(path);
     left.forEach((String key, Object leftValue) {
       if (ignored.contains(key)) {
         return;
@@ -128,7 +128,7 @@ class JsonDiffer {
 
   DiffNode _diffLists(List<Object> left, List<Object> right, String parentKey,
       List<Object> path) {
-    final node = DiffNode(List.from(path));
+    final node = DiffNode(path);
     var leftHand = 0;
     var leftFoot = 0;
     var rightHand = 0;
@@ -189,7 +189,7 @@ class JsonDiffer {
                 _diffObjects(leftObject, rightObject, [...path, leftFoot]);
           } else if (leftObject is List && rightObject is List) {
             node[leftFoot] =
-                _diffLists(leftObject, rightObject, null, [path, leftFoot]);
+                _diffLists(leftObject, rightObject, null, [...path, leftFoot]);
           } else {
             node.changed[leftFoot] = [leftObject, rightObject];
           }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: Utilities for diffing two JSON objects
 homepage: https://github.com/google/dart-json_diff
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.6.0 <3.0.0'
 dependencies:
   collection: ^1.14.13
   diff_match_patch: ^0.3.0

--- a/test/json_diff_test.dart
+++ b/test/json_diff_test.dart
@@ -5,6 +5,7 @@
 library json_diff_tests;
 
 import 'dart:convert';
+
 import 'package:json_diff/json_diff.dart';
 import 'package:test/test.dart';
 
@@ -113,7 +114,7 @@ void main() {
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
     expect(node.node['a'].added, hasLength(1));
-    expect(node.node['a'].added['2'], equals(4));
+    expect(node.node['a'].added[2], equals(4));
     expect(node.node['a'].removed, isEmpty);
     expect(node.node['a'].changed, isEmpty);
   });
@@ -126,7 +127,7 @@ void main() {
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
     expect(node.node['a'].added, hasLength(1));
-    expect(node.node['a'].added['1'], equals(4));
+    expect(node.node['a'].added[1], equals(4));
     expect(node.node['a'].removed, isEmpty);
     expect(node.node['a'].changed, isEmpty);
   });
@@ -140,8 +141,8 @@ void main() {
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
     expect(node.node['a'].added, hasLength(2));
-    expect(node.node['a'].added['1'], equals(4));
-    expect(node.node['a'].added['2'], equals(8));
+    expect(node.node['a'].added[1], equals(4));
+    expect(node.node['a'].added[2], equals(8));
     expect(node.node['a'].removed, isEmpty);
     expect(node.node['a'].changed, isEmpty);
   });
@@ -154,7 +155,7 @@ void main() {
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
     expect(node.node['a'].added, hasLength(1));
-    expect(node.node['a'].added['0'], equals(4));
+    expect(node.node['a'].added[0], equals(4));
     expect(node.node['a'].removed, isEmpty);
     expect(node.node['a'].changed, isEmpty);
   });
@@ -168,7 +169,7 @@ void main() {
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
     expect(node.node['a'].added, hasLength(1));
-    expect(node.node['a'].added['0'], equals({'z': 4}));
+    expect(node.node['a'].added[0], equals({'z': 4}));
     expect(node.node['a'].removed, isEmpty);
     expect(node.node['a'].changed, isEmpty);
   });
@@ -181,8 +182,8 @@ void main() {
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
     expect(node.node['a'].added, hasLength(2));
-    expect(node.node['a'].added['0'], equals(4));
-    expect(node.node['a'].added['1'], equals(8));
+    expect(node.node['a'].added[0], equals(4));
+    expect(node.node['a'].added[1], equals(8));
     expect(node.node['a'].removed, isEmpty);
     expect(node.node['a'].changed, isEmpty);
   });
@@ -205,8 +206,8 @@ void main() {
     expect(node.node['a'].added, isEmpty);
     expect(node.node['a'].removed, isEmpty);
     expect(node.node['a'].changed, isEmpty);
-    expect(node.node['a'].node['0'].changed, hasLength(1));
-    expect(node.node['a'].node['0'].changed['b'], equals([1, 2]));
+    expect(node.node['a'].node[0].changed, hasLength(1));
+    expect(node.node['a'].node[0].changed['b'], equals([1, 2]));
   });
 
   test(
@@ -241,9 +242,9 @@ void main() {
       ],
     }).diff();
 
-    expect(node.node['primary'].node['0'].node['resolvers'].changed['0'],
+    expect(node.node['primary'].node[0].node['resolvers'].changed[0],
         equals(['foo', 'bar']));
-    expect(node.node['primary'].node['1'].node['resolvers'].added['1'],
+    expect(node.node['primary'].node[1].node['resolvers'].added[1],
         equals('added'));
   });
 
@@ -258,11 +259,30 @@ void main() {
 
     final node = JsonDiffer.fromJson(left, right).diff();
 
-    expect(node.node['field'].changed['0'], equals([1, 2]));
-    expect(node.node['field'].added['1'], equals('added'));
+    expect(node.node['field'].changed[0], equals([1, 2]));
+    expect(node.node['field'].added[1], equals('added'));
   });
 
-  // TODO: Test metadataToKeep
+  test('JsonDiffer diff() with complex elements moved in list', () {
+    final node = JsonDiffer.fromJson({
+      'list': [
+        'xxx',
+        'xxx',
+        {'foo': 1},
+        [2],
+      ],
+    }, {
+      'list': [
+        [2],
+        {'foo': 1},
+        'xxx',
+        'xxx',
+      ],
+    }).diff();
+
+    expect(node.node['list'].moved[2], equals(1));
+    expect(node.node['list'].moved[3], equals(0));
+  });
 }
 
 String jsonFrom(Map<String, Object> obj) => JsonEncoder().convert(obj);


### PR DESCRIPTION
Identical elements added in the right list and removed in the left
(and vice versa) should be considered moved, hence this change.
This is inspired by https://github.com/benjamine/jsondiffpatch,
and many others. In order to benefit from this feature, the "path"
attribute has been added to DiffNode, which describes the JSON path with
a list of indexes/keys to reach the described property. In order to make
such a list, the indexes and keys has to retain their types, so that an
int remains an int and so forth. That way, a user can traverse the
original objects with the correct index/key type to retrieve changed
list.