### PR TITLE
Release 0.2.0 as the null safety release

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,12 +3,9 @@
 # see https://github.com/dart-lang/pedantic#enabled-lints.
 include: package:pedantic/analysis_options.yaml
 
-# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
-# Uncomment to specify additional rules.
-# linter:
-#   rules:
-#     - camel_case_types
-
 analyzer:
+  language:
+    strict-inference: true
+    strict-raw-types: true
   strong-mode:
     implicit-casts: false

--- a/lib/src/diff_node.dart
+++ b/lib/src/diff_node.dart
@@ -29,15 +29,15 @@ class DiffNode {
 
   /// A Map containing the key/value pairs that were _added_ between the left
   /// JSON and the right.
-  final added = <Object, Object>{};
+  final added = <Object, Object?>{};
 
   /// A Map containing the key/value pairs that were _removed_ between the left
   /// JSON and the right.
-  final removed = <Object, Object>{};
+  final removed = <Object, Object?>{};
 
   /// A Map whose values are 2-element arrays containing the left value and the
   /// right value, corresponding to the mapping key.
-  final Map<Object, List<Object>> changed = <Object, List<Object>>{};
+  final Map<Object, List<Object?>> changed = <Object, List<Object?>>{};
 
   /// A Map of _moved_ elements in the List, where the key is the original
   /// position, and the value is the new position.
@@ -64,12 +64,12 @@ class DiffNode {
 
   void forEach(void Function(Object s, DiffNode dn) ffn) => node.forEach(ffn);
 
-  List<Object> map(void Function(Object s, DiffNode dn) ffn) {
+  List<Object?> map(void Function(Object s, DiffNode dn) ffn) {
     final result = <void>[];
     forEach((s, dn) {
       result.add(ffn(s, dn));
     });
-    return result as List<Object>;
+    return result;
   }
 
   void forEachOf(String key, void Function(Object s, DiffNode dn) ffn) {
@@ -78,27 +78,27 @@ class DiffNode {
     }
   }
 
-  void forEachAdded(void Function(Object s, Object o) ffn) =>
+  void forEachAdded(void Function(Object s, Object? o) ffn) =>
       added.forEach(ffn);
 
-  void forEachRemoved(void Function(Object s, Object o) ffn) =>
+  void forEachRemoved(void Function(Object s, Object? o) ffn) =>
       removed.forEach(ffn);
 
-  void forEachChanged(void Function(Object s, List<Object> o) ffn) =>
+  void forEachChanged(void Function(Object s, List<Object?> o) ffn) =>
       changed.forEach(ffn);
 
-  void forAllAdded(void Function(Object k, Object o) ffn,
-      {Map<Object, Object> root = const {}}) {
+  void forAllAdded(void Function(Object? _, Object? o) ffn,
+      {Map<Object, Object?> root = const {}}) {
     added.forEach((key, thisNode) => ffn(root, thisNode));
     node.forEach((key, node) {
-      root[key] = <String, Object>{};
+      root[key] = <String, Object?>{};
       node.forAllAdded((addedMap, root) => ffn(root, addedMap),
-          root: root[key] as Map<String, Object>);
+          root: root[key] as Map<String, Object?>);
     });
   }
 
-  Map<Object, Object>? allAdded() {
-    final thisNode = <Object, Object>{};
+  Map<Object, Object?>? allAdded() {
+    final thisNode = <Object, Object?>{};
     added.forEach((k, v) {
       thisNode[k] = v;
     });

--- a/lib/src/diff_node.dart
+++ b/lib/src/diff_node.dart
@@ -37,7 +37,7 @@ class DiffNode {
 
   /// A Map whose values are 2-element arrays containing the left value and the
   /// right value, corresponding to the mapping key.
-  final changed = <Object, List<Object>>{};
+  final Map<Object, List<Object>> changed = <Object, List<Object>>{};
 
   /// A Map of _moved_ elements in the List, where the key is the original
   /// position, and the value is the new position.
@@ -49,14 +49,11 @@ class DiffNode {
 
   /// A convenience method for `node[]=`.
   void operator []=(Object s, DiffNode d) {
-    if (d == null) {
-      return;
-    }
     node[s] = d;
   }
 
   /// A convenience method for `node[]`.
-  DiffNode operator [](Object s) {
+  DiffNode? operator [](Object s) {
     return node[s];
   }
 
@@ -65,42 +62,30 @@ class DiffNode {
     return node.containsKey(s);
   }
 
-  void forEach(void Function(Object s, DiffNode dn) ffn) {
-    if (node != null) {
-      node.forEach(ffn);
-    }
-  }
+  void forEach(void Function(Object s, DiffNode dn) ffn) => node.forEach(ffn);
 
   List<Object> map(void Function(Object s, DiffNode dn) ffn) {
     final result = <void>[];
-    if (node != null) {
-      forEach((s, dn) {
-        result.add(ffn(s, dn));
-      });
-    }
-    return result;
+    forEach((s, dn) {
+      result.add(ffn(s, dn));
+    });
+    return result as List<Object>;
   }
 
   void forEachOf(String key, void Function(Object s, DiffNode dn) ffn) {
-    if (node == null) {
-      return;
-    }
     if (node.containsKey(key)) {
-      node[key].forEach(ffn);
+      node[key]!.forEach(ffn);
     }
   }
 
-  void forEachAdded(void Function(Object s, Object o) ffn) {
-    added.forEach(ffn);
-  }
+  void forEachAdded(void Function(Object s, Object o) ffn) =>
+      added.forEach(ffn);
 
-  void forEachRemoved(void Function(Object s, Object o) ffn) {
-    removed.forEach(ffn);
-  }
+  void forEachRemoved(void Function(Object s, Object o) ffn) =>
+      removed.forEach(ffn);
 
-  void forEachChanged(void Function(Object s, List<Object> o) ffn) {
-    changed.forEach(ffn);
-  }
+  void forEachChanged(void Function(Object s, List<Object> o) ffn) =>
+      changed.forEach(ffn);
 
   void forAllAdded(void Function(Object k, Object o) ffn,
       {Map<Object, Object> root = const {}}) {
@@ -112,7 +97,7 @@ class DiffNode {
     });
   }
 
-  Map<Object, Object> allAdded() {
+  Map<Object, Object>? allAdded() {
     final thisNode = <Object, Object>{};
     added.forEach((k, v) {
       thisNode[k] = v;
@@ -122,7 +107,7 @@ class DiffNode {
       if (down == null) {
         return;
       }
-      thisNode[k] = v.allAdded();
+      thisNode[k] = down;
     });
 
     if (thisNode.isEmpty) {
@@ -150,7 +135,7 @@ class DiffNode {
     var keys = node.keys.toList();
     for (var i = keys.length - 1; i >= 0; i--) {
       final key = keys[i];
-      final d = node[key];
+      final d = node[key]!;
       d.prune();
       if (d.hasNothing) {
         node.remove(key);

--- a/lib/src/json_differ.dart
+++ b/lib/src/json_differ.dart
@@ -5,7 +5,7 @@ part of json_diff;
 
 /// A configurable class that can produce a diff of two JSON Strings.
 class JsonDiffer {
-  Object leftJson, rightJson;
+  final Object leftJson, rightJson;
   final List<String> atomics = <String>[];
   final List<String> ignored = <String>[];
 
@@ -19,22 +19,10 @@ class JsonDiffer {
   JsonDiffer(
     String leftString,
     String rightString,
-  ) {
-    leftJson = jsonDecode(leftString);
-    rightJson = jsonDecode(rightString);
-  }
+  )   : leftJson = jsonDecode(leftString) as Object,
+        rightJson = jsonDecode(rightString) as Object;
 
-  JsonDiffer.fromJson(
-    Object leftJson,
-    Object rightJson,
-  ) {
-    if (leftJson != null && rightJson != null) {
-      this.leftJson = leftJson;
-      this.rightJson = rightJson;
-    } else {
-      throw FormatException('JSON must not be null');
-    }
-  }
+  JsonDiffer.fromJson(this.leftJson, this.rightJson);
 
   /// Compare the two JSON Strings, producing a [DiffNode].
   ///
@@ -50,7 +38,8 @@ class JsonDiffer {
         [],
       )..prune();
     } else if (leftJson is List && rightJson is List) {
-      return _diffLists(leftJson as List, rightJson as List, null, []);
+      return _diffLists((leftJson as List).cast<Object>(),
+          (rightJson as List).cast<Object>(), null, []);
     }
     return DiffNode([])..changed[''] = [leftJson, rightJson];
   }
@@ -69,19 +58,20 @@ class JsonDiffer {
         return;
       }
 
-      final rightValue = right[key];
+      final rightValue = right[key]!;
       if (atomics.contains(key) &&
           leftValue.toString() != rightValue.toString()) {
-        // Treat leftValue and rightValue as atomic objects, even if they are
-        // deep maps or some such thing.
+        // Treat [leftValue] and [rightValue] as atomic objects, even if they
+        // are deep maps or some such thing.
         node.changed[key] = [leftValue, rightValue];
       } else if (leftValue is List && rightValue is List) {
-        node[key] = _diffLists(leftValue, rightValue, key, [...path, key]);
+        node[key] = _diffLists(leftValue.cast<Object>(),
+            rightValue.cast<Object>(), key, [...path, key]);
       } else if (leftValue is Map && rightValue is Map) {
         node[key] = _diffObjects(leftValue.cast<String, Object>(),
             rightValue.cast<String, Object>(), [...path, key]);
       } else if (leftValue != rightValue) {
-        // value is different between [left] and [right]
+        // value is different between [left] and [right].
         node.changed[key] = [leftValue, rightValue];
       }
     });
@@ -100,9 +90,10 @@ class JsonDiffer {
     return node;
   }
 
-  bool _deepEquals(e1, e2) => DeepCollectionEquality.unordered().equals(e1, e2);
+  bool _deepEquals(Object e1, Object e2) =>
+      DeepCollectionEquality.unordered().equals(e1, e2);
 
-  DiffNode _diffLists(List<Object> left, List<Object> right, String parentKey,
+  DiffNode _diffLists(List<Object> left, List<Object> right, String? parentKey,
       List<Object> path) {
     final node = DiffNode(path);
     var leftHand = 0;
@@ -146,8 +137,8 @@ class JsonDiffer {
         }
 
         if (!foundMissing) {
-          // Never found left[leftFoot] in right, nor right[rightFoot] in left.
-          // This must just be a changed value.
+          // Never found `left[leftFoot]` in [right], nor `right[rightFoot]` in
+          // [left]. This must just be a changed value.
           // TODO: This notation is wrong for a case such as:
           //     [1,2,3,4,5,6] => [1,4,5,7]
           //     changed.first = [[5, 6], [3,7]
@@ -163,8 +154,8 @@ class JsonDiffer {
             node[leftFoot] = _diffObjects(leftObject.cast<String, Object>(),
                 rightObject.cast<String, Object>(), [...path, leftFoot]);
           } else if (leftObject is List && rightObject is List) {
-            node[leftFoot] =
-                _diffLists(leftObject, rightObject, null, [...path, leftFoot]);
+            node[leftFoot] = _diffLists(leftObject.cast<Object>(),
+                rightObject.cast<Object>(), null, [...path, leftFoot]);
           } else {
             node.changed[leftFoot] = [leftObject, rightObject];
           }
@@ -193,13 +184,13 @@ class JsonDiffer {
           .removeFirstWhere((key, value) => _deepEquals(e.value, value));
 
       if (added != null) {
-        // We've found an equal element in added,
-        // put the element in moved and filter it out from removed.
+        // We've found an equal element in [added], put the element in
+        // `node.moved` and filtered it out from `node.removed`.
         node.moved[e.key as int] = added.key as int;
         return false;
       }
 
-      // Element are not present in added, it is simply removed
+      // Element is not present in [added]; it is simply removed.
       return true;
     }).toList();
 
@@ -221,7 +212,7 @@ class UncomparableJsonException implements Exception {
 }
 
 extension<K, V> on Map<K, V> {
-  MapEntry<K, V> removeFirstWhere(bool Function(K, V) test) {
+  MapEntry<K, V>? removeFirstWhere(bool Function(K, V) test) {
     for (final entry in entries) {
       if (test(entry.key, entry.value)) {
         remove(entry.key);

--- a/lib/src/json_differ.dart
+++ b/lib/src/json_differ.dart
@@ -33,21 +33,21 @@ class JsonDiffer {
   DiffNode diff() {
     if (leftJson is Map && rightJson is Map) {
       return _diffObjects(
-        (leftJson as Map).cast<String, Object>(),
-        (rightJson as Map).cast<String, Object>(),
+        (leftJson as Map).cast<String, Object?>(),
+        (rightJson as Map).cast<String, Object?>(),
         [],
       )..prune();
     } else if (leftJson is List && rightJson is List) {
-      return _diffLists((leftJson as List).cast<Object>(),
-          (rightJson as List).cast<Object>(), null, []);
+      return _diffLists((leftJson as List).cast<Object?>(),
+          (rightJson as List).cast<Object?>(), null, []);
     }
     return DiffNode([])..changed[''] = [leftJson, rightJson];
   }
 
-  DiffNode _diffObjects(
-      Map<String, Object> left, Map<String, Object> right, List<Object> path) {
+  DiffNode _diffObjects(Map<String, Object?> left, Map<String, Object?> right,
+      List<Object> path) {
     final node = DiffNode(path);
-    left.forEach((String key, Object leftValue) {
+    left.forEach((String key, Object? leftValue) {
       if (ignored.contains(key)) {
         return;
       }
@@ -58,25 +58,25 @@ class JsonDiffer {
         return;
       }
 
-      final rightValue = right[key]!;
+      final rightValue = right[key];
       if (atomics.contains(key) &&
           leftValue.toString() != rightValue.toString()) {
         // Treat [leftValue] and [rightValue] as atomic objects, even if they
         // are deep maps or some such thing.
         node.changed[key] = [leftValue, rightValue];
       } else if (leftValue is List && rightValue is List) {
-        node[key] = _diffLists(leftValue.cast<Object>(),
-            rightValue.cast<Object>(), key, [...path, key]);
+        node[key] = _diffLists(leftValue.cast<Object?>(),
+            rightValue.cast<Object?>(), key, [...path, key]);
       } else if (leftValue is Map && rightValue is Map) {
-        node[key] = _diffObjects(leftValue.cast<String, Object>(),
-            rightValue.cast<String, Object>(), [...path, key]);
+        node[key] = _diffObjects(leftValue.cast<String, Object?>(),
+            rightValue.cast<String, Object?>(), [...path, key]);
       } else if (leftValue != rightValue) {
         // value is different between [left] and [right].
         node.changed[key] = [leftValue, rightValue];
       }
     });
 
-    right.forEach((String key, Object value) {
+    right.forEach((String key, Object? value) {
       if (ignored.contains(key)) {
         return;
       }
@@ -90,11 +90,11 @@ class JsonDiffer {
     return node;
   }
 
-  bool _deepEquals(Object e1, Object e2) =>
+  bool _deepEquals(Object? e1, Object? e2) =>
       DeepCollectionEquality.unordered().equals(e1, e2);
 
-  DiffNode _diffLists(List<Object> left, List<Object> right, String? parentKey,
-      List<Object> path) {
+  DiffNode _diffLists(List<Object?> left, List<Object?> right,
+      String? parentKey, List<Object> path) {
     final node = DiffNode(path);
     var leftHand = 0;
     var leftFoot = 0;
@@ -151,11 +151,11 @@ class JsonDiffer {
             // deep maps or some such thing.
             node.changed[leftFoot] = [leftObject, rightObject];
           } else if (leftObject is Map && rightObject is Map) {
-            node[leftFoot] = _diffObjects(leftObject.cast<String, Object>(),
-                rightObject.cast<String, Object>(), [...path, leftFoot]);
+            node[leftFoot] = _diffObjects(leftObject.cast<String, Object?>(),
+                rightObject.cast<String, Object?>(), [...path, leftFoot]);
           } else if (leftObject is List && rightObject is List) {
-            node[leftFoot] = _diffLists(leftObject.cast<Object>(),
-                rightObject.cast<Object>(), null, [...path, leftFoot]);
+            node[leftFoot] = _diffLists(leftObject.cast<Object?>(),
+                rightObject.cast<Object?>(), null, [...path, leftFoot]);
           } else {
             node.changed[leftFoot] = [leftObject, rightObject];
           }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: json_diff
-version: 0.1.3
+version: 0.2.0
 author: Sam Rawlins <srawlins@google.com>
 description: Utilities for diffing two JSON objects
 homepage: https://github.com/google/dart-json_diff
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies:
   collection: ^1.14.13
   diff_match_patch: ^0.3.0
 dev_dependencies:
   test: ^1.6.4
-  pedantic: ^1.9.2
+  pedantic: ^1.11.0

--- a/test/atomics_test.dart
+++ b/test/atomics_test.dart
@@ -72,7 +72,7 @@ void main() {
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
 
-    var innerNode = node.node['a'];
+    var innerNode = node.node['a']!;
     expect(innerNode.changed, hasLength(1));
     expect(
         innerNode.changed['y'],
@@ -81,7 +81,7 @@ void main() {
           {'z': 4}
         ]));
 
-    innerNode = node.node['a']['x'];
+    innerNode = node.node['a']!['x']!;
     expect(innerNode.changed, hasLength(1));
     expect(
         innerNode.changed['y'],

--- a/test/json_diff_test.dart
+++ b/test/json_diff_test.dart
@@ -27,7 +27,7 @@ void main() {
   });
 
   test('JsonDiffer diff() identical lists', () {
-    differ = JsonDiffer.fromJson([1, 2, 3], [1, 2, 3]);
+    differ = JsonDiffer.fromJson([1, 2, null], [1, 2, null]);
     final node = differ.diff();
     expect(node.added, isEmpty);
     expect(node.removed, isEmpty);
@@ -48,10 +48,10 @@ void main() {
   });
 
   test('JsonDiffer diff() with a new value', () {
-    differ = JsonDiffer('{"a": 1}', '{"a": 1, "b": 2}');
+    differ = JsonDiffer('{"a": 1}', '{"a": 1, "b": null}');
     final node = differ.diff();
     expect(node.added, hasLength(1));
-    expect(node.added['b'], equals(2));
+    expect(node.added['b'], equals(null));
     expect(node.removed, isEmpty);
     expect(node.changed, isEmpty);
     expect(node.node, isEmpty);
@@ -61,6 +61,15 @@ void main() {
     differ = JsonDiffer.fromJson([1, 2, 3], [1, 2, 3, 4]);
     final node = differ.diff();
     expect(node.added[3], equals(4));
+    expect(node.removed, isEmpty);
+    expect(node.changed, isEmpty);
+    expect(node.node, isEmpty);
+  });
+
+  test('JsonDiffer diff() lists with a new null value', () {
+    differ = JsonDiffer.fromJson([1, 2, 3], [1, 2, 3, null]);
+    final node = differ.diff();
+    expect(node.added[3], equals(null));
     expect(node.removed, isEmpty);
     expect(node.changed, isEmpty);
     expect(node.node, isEmpty);
@@ -98,6 +107,15 @@ void main() {
     expect(node.node, isEmpty);
   });
 
+  test('JsonDiffer diff() lists with a removed null value', () {
+    differ = JsonDiffer.fromJson([1, 2, 3, null], [1, 2, 3]);
+    final node = differ.diff();
+    expect(node.added, isEmpty);
+    expect(node.removed[3], equals(null));
+    expect(node.changed, isEmpty);
+    expect(node.node, isEmpty);
+  });
+
   test('JsonDiffer diff() with a changed value', () {
     differ = JsonDiffer('{"a": 1}', '{"a": 2}');
     final node = differ.diff();
@@ -105,6 +123,16 @@ void main() {
     expect(node.removed, isEmpty);
     expect(node.changed, hasLength(1));
     expect(node.changed['a'], equals([1, 2]));
+    expect(node.node, isEmpty);
+  });
+
+  test('JsonDiffer diff() with a changed value, to null', () {
+    differ = JsonDiffer('{"a": 1}', '{"a": null}');
+    final node = differ.diff();
+    expect(node.added, isEmpty);
+    expect(node.removed, isEmpty);
+    expect(node.changed, hasLength(1));
+    expect(node.changed['a'], equals([1, null]));
     expect(node.node, isEmpty);
   });
 
@@ -307,5 +335,3 @@ void main() {
     expect(node.node['list']!.moved[3], equals(0));
   });
 }
-
-String jsonFrom(Map<String, Object> obj) => JsonEncoder().convert(obj);

--- a/test/json_diff_test.dart
+++ b/test/json_diff_test.dart
@@ -73,10 +73,10 @@ void main() {
     expect(node.removed, isEmpty);
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
-    expect(node.node['a'].added, hasLength(1));
-    expect(node.node['a'].added['y'], equals({'p': 2}));
-    expect(node.node['a'].removed, isEmpty);
-    expect(node.node['a'].changed, isEmpty);
+    expect(node.node['a']!.added, hasLength(1));
+    expect(node.node['a']!.added['y'], equals({'p': 2}));
+    expect(node.node['a']!.removed, isEmpty);
+    expect(node.node['a']!.changed, isEmpty);
   });
 
   test('JsonDiffer diff() with a removed value', () {
@@ -124,7 +124,7 @@ void main() {
     expect(node.removed, isEmpty);
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
-    final innerNode = node.node['a'];
+    final innerNode = node.node['a']!;
     expect(innerNode.changed, hasLength(1));
     expect(innerNode.changed['x'], equals([1, 2]));
   });
@@ -136,10 +136,10 @@ void main() {
     expect(node.removed, isEmpty);
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
-    expect(node.node['a'].added, hasLength(1));
-    expect(node.node['a'].added[2], equals(4));
-    expect(node.node['a'].removed, isEmpty);
-    expect(node.node['a'].changed, isEmpty);
+    expect(node.node['a']!.added, hasLength(1));
+    expect(node.node['a']!.added[2], equals(4));
+    expect(node.node['a']!.removed, isEmpty);
+    expect(node.node['a']!.changed, isEmpty);
   });
 
   test('JsonDiffer diff() with a new value in the middle of a list', () {
@@ -149,10 +149,10 @@ void main() {
     expect(node.removed, isEmpty);
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
-    expect(node.node['a'].added, hasLength(1));
-    expect(node.node['a'].added[1], equals(4));
-    expect(node.node['a'].removed, isEmpty);
-    expect(node.node['a'].changed, isEmpty);
+    expect(node.node['a']!.added, hasLength(1));
+    expect(node.node['a']!.added[1], equals(4));
+    expect(node.node['a']!.removed, isEmpty);
+    expect(node.node['a']!.changed, isEmpty);
   });
 
   test('JsonDiffer diff() with multiple new values in the middle of a list',
@@ -163,11 +163,11 @@ void main() {
     expect(node.removed, isEmpty);
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
-    expect(node.node['a'].added, hasLength(2));
-    expect(node.node['a'].added[1], equals(4));
-    expect(node.node['a'].added[2], equals(8));
-    expect(node.node['a'].removed, isEmpty);
-    expect(node.node['a'].changed, isEmpty);
+    expect(node.node['a']!.added, hasLength(2));
+    expect(node.node['a']!.added[1], equals(4));
+    expect(node.node['a']!.added[2], equals(8));
+    expect(node.node['a']!.removed, isEmpty);
+    expect(node.node['a']!.changed, isEmpty);
   });
 
   test('JsonDiffer diff() with a new value at the start of a list', () {
@@ -177,10 +177,10 @@ void main() {
     expect(node.removed, isEmpty);
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
-    expect(node.node['a'].added, hasLength(1));
-    expect(node.node['a'].added[0], equals(4));
-    expect(node.node['a'].removed, isEmpty);
-    expect(node.node['a'].changed, isEmpty);
+    expect(node.node['a']!.added, hasLength(1));
+    expect(node.node['a']!.added[0], equals(4));
+    expect(node.node['a']!.removed, isEmpty);
+    expect(node.node['a']!.changed, isEmpty);
   });
 
   test('JsonDiffer diff() with a new object at the start of a list', () {
@@ -191,10 +191,10 @@ void main() {
     expect(node.removed, isEmpty);
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
-    expect(node.node['a'].added, hasLength(1));
-    expect(node.node['a'].added[0], equals({'z': 4}));
-    expect(node.node['a'].removed, isEmpty);
-    expect(node.node['a'].changed, isEmpty);
+    expect(node.node['a']!.added, hasLength(1));
+    expect(node.node['a']!.added[0], equals({'z': 4}));
+    expect(node.node['a']!.removed, isEmpty);
+    expect(node.node['a']!.changed, isEmpty);
   });
 
   test('JsonDiffer diff() with multiple new values at the start of a list', () {
@@ -204,11 +204,11 @@ void main() {
     expect(node.removed, isEmpty);
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
-    expect(node.node['a'].added, hasLength(2));
-    expect(node.node['a'].added[0], equals(4));
-    expect(node.node['a'].added[1], equals(8));
-    expect(node.node['a'].removed, isEmpty);
-    expect(node.node['a'].changed, isEmpty);
+    expect(node.node['a']!.added, hasLength(2));
+    expect(node.node['a']!.added[0], equals(4));
+    expect(node.node['a']!.added[1], equals(8));
+    expect(node.node['a']!.removed, isEmpty);
+    expect(node.node['a']!.changed, isEmpty);
   });
 
   test('JsonDiffer diff() with a changed value at the start of a list', () {
@@ -226,11 +226,11 @@ void main() {
     expect(node.removed, isEmpty);
     expect(node.changed, isEmpty);
     expect(node.node, hasLength(1));
-    expect(node.node['a'].added, isEmpty);
-    expect(node.node['a'].removed, isEmpty);
-    expect(node.node['a'].changed, isEmpty);
-    expect(node.node['a'].node[0].changed, hasLength(1));
-    expect(node.node['a'].node[0].changed['b'], equals([1, 2]));
+    expect(node.node['a']!.added, isEmpty);
+    expect(node.node['a']!.removed, isEmpty);
+    expect(node.node['a']!.changed, isEmpty);
+    expect(node.node['a']!.node[0]!.changed, hasLength(1));
+    expect(node.node['a']!.node[0]!.changed['b'], equals([1, 2]));
   });
 
   test(
@@ -265,9 +265,9 @@ void main() {
       ],
     }).diff();
 
-    expect(node.node['primary'].node[0].node['resolvers'].changed[0],
+    expect(node.node['primary']!.node[0]!.node['resolvers']!.changed[0],
         equals(['foo', 'bar']));
-    expect(node.node['primary'].node[1].node['resolvers'].added[1],
+    expect(node.node['primary']!.node[1]!.node['resolvers']!.added[1],
         equals('added'));
   });
 
@@ -282,8 +282,8 @@ void main() {
 
     final node = JsonDiffer.fromJson(left, right).diff();
 
-    expect(node.node['field'].changed[0], equals([1, 2]));
-    expect(node.node['field'].added[1], equals('added'));
+    expect(node.node['field']!.changed[0], equals([1, 2]));
+    expect(node.node['field']!.added[1], equals('added'));
   });
 
   test('JsonDiffer diff() with complex elements moved in list', () {
@@ -303,8 +303,8 @@ void main() {
       ],
     }).diff();
 
-    expect(node.node['list'].moved[2], equals(1));
-    expect(node.node['list'].moved[3], equals(0));
+    expect(node.node['list']!.moved[2], equals(1));
+    expect(node.node['list']!.moved[3], equals(0));
   });
 }
 


### PR DESCRIPTION
* Bump minimum SDK version to 2.12.0
  * This triggers the null safety language feature. Almost all types in json_diff are _non_-nullable. The output from `jsonDecode` is aaaaall `dynamic` though, so we still have need plenty of casts. The casts are generally to non-nullable types.
* Bump pedantic to 1.11.0
* Enable `strict-inference` and `strict-raw-types` analysis modes.